### PR TITLE
[#65] feat: 좋아요 순으로 정렬 기능 구현

### DIFF
--- a/src/main/java/chat/teco/tecochat/chat/query/dao/ChatQueryDao.java
+++ b/src/main/java/chat/teco/tecochat/chat/query/dao/ChatQueryDao.java
@@ -1,16 +1,25 @@
 package chat.teco.tecochat.chat.query.dao;
 
 import static chat.teco.tecochat.chat.domain.chat.QChat.chat;
+import static chat.teco.tecochat.like.chatlike.domain.QChatLike.chatLike;
 import static chat.teco.tecochat.member.domain.QMember.member;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.LocalTime.MIN;
+import static java.time.temporal.TemporalAdjusters.previousOrSame;
 import static org.springframework.util.StringUtils.hasText;
 
 import chat.teco.tecochat.chat.domain.chat.Chat;
 import chat.teco.tecochat.common.entity.BaseEntity;
+import chat.teco.tecochat.common.query.OrderByNull;
 import chat.teco.tecochat.member.domain.Course;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.function.Supplier;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -21,17 +30,23 @@ public class ChatQueryDao {
 
     private final JPAQueryFactory query;
 
-    public ChatQueryDao(final JPAQueryFactory query) {
+    public ChatQueryDao(JPAQueryFactory query) {
         this.query = query;
     }
 
-    public Page<Chat> search(final ChatSearchCond cond, final Pageable pageable) {
-        final List<Long> longs = nameAndCourseMatchMemberIds(cond);
-        final List<Chat> contents = query.selectFrom(chat)
+    public Page<Chat> search(ChatSearchCond cond, Pageable pageable) {
+        List<Long> longs = nameAndCourseMatchMemberIds(cond);
+        List<Chat> contents = query.selectFrom(chat)
+                .leftJoin(chatLike).on(chatLike.chatId.eq(chat.id))
                 .where(
+                        likeCondition(cond.likeCond()),
                         titleLikeIgnoreCase(cond.title),
                         chat.memberId.in(longs)
-                ).orderBy(chat.createdAt.desc())
+                )
+                .orderBy(
+                        likeCountDesc(cond.likeCond),
+                        chat.createdAt.desc()
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -42,32 +57,64 @@ public class ChatQueryDao {
     }
 
     /* 이름과 코스에 해당하는 회원 id 조회 */
-    private List<Long> nameAndCourseMatchMemberIds(final ChatSearchCond cond) {
+    private List<Long> nameAndCourseMatchMemberIds(ChatSearchCond cond) {
         return query.selectFrom(member)
                 .where(
                         nameLikeIgnoreCase(cond.name),
-                        courseEquals(cond.course)).fetch()
+                        courseEquals(cond.course)
+                ).fetch()
                 .stream()
                 .map(BaseEntity::id)
                 .toList();
     }
 
-    private BooleanExpression nameLikeIgnoreCase(final String name) {
+    private BooleanExpression nameLikeIgnoreCase(String name) {
         return hasText(name) ? member.name.likeIgnoreCase("%" + name.strip() + "%") : null;
     }
 
-    private BooleanExpression courseEquals(final Course course) {
+    private BooleanExpression courseEquals(Course course) {
         return (course == null) ? null : member.course.eq(course);
     }
 
-    private BooleanExpression titleLikeIgnoreCase(final String title) {
+    private BooleanExpression titleLikeIgnoreCase(String title) {
         return hasText(title) ? chat.title.likeIgnoreCase("%" + title.strip() + "%") : null;
+    }
+
+    private Predicate likeCondition(LikeCond likeCond) {
+        return (likeCond == null) ? null : likeCreateAtAfter(likeCond.dataCondition());
+    }
+
+    private Predicate likeCreateAtAfter(LocalDateTime localDateTime) {
+        return (localDateTime == null) ? null : chatLike.createdAt.goe(localDateTime);
+    }
+
+    private OrderSpecifier<?> likeCountDesc(LikeCond likeCond) {
+        return (likeCond == null) ? OrderByNull.getDefault() : chat.likeCount.desc();
+    }
+
+    public enum LikeCond {
+        TODAY(() -> LocalDateTime.now().with(MIN)),
+        WEEK(() -> LocalDateTime.now().with(previousOrSame(MONDAY)).with(MIN)),
+        MONTH(() -> LocalDateTime.now().withDayOfMonth(1).with(MIN)),
+        YEAR(() -> LocalDateTime.now().withDayOfYear(1).with(MIN)),
+        ALL(() -> null);
+
+        private final Supplier<LocalDateTime> localDateTimeSupplier;
+
+        LikeCond(Supplier<LocalDateTime> localDateSupplier) {
+            this.localDateTimeSupplier = localDateSupplier;
+        }
+
+        public LocalDateTime dataCondition() {
+            return localDateTimeSupplier.get();
+        }
     }
 
     public record ChatSearchCond(
             String name,
             String title,
-            Course course
+            Course course,
+            LikeCond likeCond
     ) {
     }
 }

--- a/src/main/java/chat/teco/tecochat/common/query/OrderByNull.java
+++ b/src/main/java/chat/teco/tecochat/common/query/OrderByNull.java
@@ -1,0 +1,18 @@
+package chat.teco.tecochat.common.query;
+
+import com.querydsl.core.types.NullExpression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+
+public class OrderByNull extends OrderSpecifier {
+
+    private static final OrderByNull DEFAULT = new OrderByNull();
+
+    private OrderByNull() {
+        super(Order.ASC, NullExpression.DEFAULT, NullHandling.Default);
+    }
+
+    public static OrderByNull getDefault() {
+        return OrderByNull.DEFAULT;
+    }
+}

--- a/src/test/java/chat/teco/tecochat/acceptance/chat/ChatAcceptanceTest.java
+++ b/src/test/java/chat/teco/tecochat/acceptance/chat/ChatAcceptanceTest.java
@@ -2,9 +2,14 @@ package chat.teco.tecochat.acceptance.chat;
 
 import static chat.teco.tecochat.acceptance.chat.ChatSteps.검색_결과_없음;
 import static chat.teco.tecochat.acceptance.chat.ChatSteps.검색_결과의_내용_검증;
+import static chat.teco.tecochat.acceptance.chat.ChatSteps.과정_조건;
 import static chat.teco.tecochat.acceptance.chat.ChatSteps.단일_채팅_조회_결과를_확인한다;
 import static chat.teco.tecochat.acceptance.chat.ChatSteps.단일_채팅_조회_요청;
-import static chat.teco.tecochat.acceptance.chat.ChatSteps.이름_과정_제목으로_검색_요청;
+import static chat.teco.tecochat.acceptance.chat.ChatSteps.요청_파라미터들;
+import static chat.teco.tecochat.acceptance.chat.ChatSteps.이름_과정_제목_좋아요_기간으로_검색_요청;
+import static chat.teco.tecochat.acceptance.chat.ChatSteps.이름_조건;
+import static chat.teco.tecochat.acceptance.chat.ChatSteps.제목_조건;
+import static chat.teco.tecochat.acceptance.chat.ChatSteps.좋아요_기간_조겅;
 import static chat.teco.tecochat.acceptance.chat.ChatSteps.채팅_이어하기_요청;
 import static chat.teco.tecochat.acceptance.chat.ChatSteps.첫_채팅_요청;
 import static chat.teco.tecochat.acceptance.chat.ChatSteps.첫_채팅_요청후_ID_반환;
@@ -12,23 +17,22 @@ import static chat.teco.tecochat.acceptance.chat.ChatSteps.첫_채팅의_응답�
 import static chat.teco.tecochat.acceptance.common.AcceptanceTestSteps.비어있음;
 import static chat.teco.tecochat.acceptance.common.AcceptanceTestSteps.요청_결과의_상태를_검증한다;
 import static chat.teco.tecochat.acceptance.common.AcceptanceTestSteps.정상_생성;
+import static chat.teco.tecochat.acceptance.like.chat.ChatLikeSteps.좋아요_요청;
 import static chat.teco.tecochat.acceptance.member.MemberSteps.회원_가입_요청;
 import static chat.teco.tecochat.chat.fixture.ChatFixture.검색시_조회될_채팅_키워드;
 import static chat.teco.tecochat.chat.fixture.ChatFixture.단일_채팅_조회의_예상_결과;
 import static chat.teco.tecochat.chat.fixture.ChatFixture.단일_채팅_키워드;
 import static chat.teco.tecochat.chat.fixture.ChatFixture.대화_내용;
-import static chat.teco.tecochat.chat.fixture.ChatFixture.채팅_검색의_예상_결과;
-import static chat.teco.tecochat.chat.fixture.ChatFixture.채팅_검색의_예상_결과들;
+import static chat.teco.tecochat.chat.fixture.ChatFixture.채팅_검색_결과;
+import static chat.teco.tecochat.chat.fixture.ChatFixture.채팅_검색_결과들;
+import static chat.teco.tecochat.chat.query.dao.ChatQueryDao.LikeCond.TODAY;
 import static chat.teco.tecochat.member.domain.Course.ANDROID;
 import static chat.teco.tecochat.member.domain.Course.BACKEND;
 import static chat.teco.tecochat.member.domain.Course.FRONTEND;
 import static org.mockito.BDDMockito.reset;
 
 import chat.teco.tecochat.chat.domain.chat.GptClient;
-import chat.teco.tecochat.chat.query.usecase.SearchChatUseCase.SearchChatResponse;
 import io.restassured.RestAssured;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -126,10 +130,14 @@ public class ChatAcceptanceTest {
         첫_채팅_요청(gptClient, "프론트2 말랑", "안녕3?", "응 안녕3");
 
         // when & then
-        var 검색_응답 = 이름_과정_제목으로_검색_요청("말랑", FRONTEND, "안녕");
+        var 요청_파라미터들 = 요청_파라미터들();
+        이름_조건(요청_파라미터들, "말랑");
+        과정_조건(요청_파라미터들, FRONTEND);
+        제목_조건(요청_파라미터들, "안녕");
+        var 검색_결과 = 이름_과정_제목_좋아요_기간으로_검색_요청(요청_파라미터들);
 
-        var 예상_채팅_내용들 = 채팅_검색의_예상_결과들(
-                채팅_검색의_예상_결과(
+        var 예상_채팅_내용들 = 채팅_검색_결과들(
+                채팅_검색_결과(
                         3L,
                         3L,
                         "프론트2 말랑",
@@ -138,7 +146,7 @@ public class ChatAcceptanceTest {
                         0,
                         1,
                         비어있음()),
-                채팅_검색의_예상_결과(
+                채팅_검색_결과(
                         2L,
                         2L,
                         "프론트 말랑",
@@ -148,7 +156,7 @@ public class ChatAcceptanceTest {
                         1,
                         비어있음())
         );
-        검색_결과의_내용_검증(검색_응답, 예상_채팅_내용들);
+        검색_결과의_내용_검증(검색_결과, 예상_채팅_내용들);
     }
 
     @Test
@@ -159,20 +167,25 @@ public class ChatAcceptanceTest {
         첫_채팅_요청(gptClient, "안드로이드 말랑", "안녕?", "응 안녕", "안드로이드", "인사", "안부");
 
         // when & then
-        var 검색_응답 = 이름_과정_제목으로_검색_요청("말랑", ANDROID, "안녕");
+        var 요청_파라미터들 = 요청_파라미터들();
+        이름_조건(요청_파라미터들, "말랑");
+        과정_조건(요청_파라미터들, ANDROID);
+        제목_조건(요청_파라미터들, "안녕");
+        var 검색_결과 = 이름_과정_제목_좋아요_기간으로_검색_요청(요청_파라미터들);
 
-        List<SearchChatResponse> 예상_채팅_내용들 = new ArrayList<>();
-
-        예상_채팅_내용들.add(채팅_검색의_예상_결과(
-                1L,
-                1L,
-                "안드로이드 말랑",
-                ANDROID,
-                "안녕?",
-                0,
-                1,
-                검색시_조회될_채팅_키워드("안드로이드", "인사", "안부")));
-        검색_결과의_내용_검증(검색_응답, 예상_채팅_내용들);
+        var 예상_채팅_내용들 = 채팅_검색_결과들(
+                채팅_검색_결과(
+                        1L,
+                        1L,
+                        "안드로이드 말랑",
+                        ANDROID,
+                        "안녕?",
+                        0,
+                        1,
+                        검색시_조회될_채팅_키워드("안드로이드", "인사", "안부")
+                )
+        );
+        검색_결과의_내용_검증(검색_결과, 예상_채팅_내용들);
     }
 
     @Test
@@ -183,7 +196,54 @@ public class ChatAcceptanceTest {
         첫_채팅_요청(gptClient, "안드로이드 허브", "안녕?", "응 안녕");
 
         // when & then
-        var 검색_결과 = 이름_과정_제목으로_검색_요청("허브_좋아요", FRONTEND, "매치안됨");
+        var 요청_파라미터들 = 요청_파라미터들();
+        이름_조건(요청_파라미터들, "허브_좋아요");
+        과정_조건(요청_파라미터들, FRONTEND);
+        제목_조건(요청_파라미터들, "매치안됨");
+        var 검색_결과 = 이름_과정_제목_좋아요_기간으로_검색_요청(요청_파라미터들);
         검색_결과_없음(검색_결과);
+    }
+
+    @Test
+    void 좋아요_순으로_정렬한다() {
+        // given
+        회원_가입_요청("말랑", BACKEND);
+        회원_가입_요청("허브", ANDROID);
+
+        첫_채팅_요청(gptClient, "말랑", "안녕?", "응 안녕");
+        Long 말랑채팅_ID = 첫_채팅_요청후_ID_반환(gptClient, "말랑", "안녕? - 좋아요", "응 안녕");
+        Long 허브채팅_ID = 첫_채팅_요청후_ID_반환(gptClient, "허브", "안녕? - 좋아요", "응 안녕");
+        첫_채팅_요청(gptClient, "허브", "안녕?", "응 안녕");
+
+        좋아요_요청("말랑", 말랑채팅_ID);
+        좋아요_요청("허브", 말랑채팅_ID);
+        좋아요_요청("허브", 허브채팅_ID);
+
+        // when & then
+        var 요청_파라미터들 = 요청_파라미터들();
+        좋아요_기간_조겅(요청_파라미터들, TODAY);
+        var 검색_결과 = 이름_과정_제목_좋아요_기간으로_검색_요청(요청_파라미터들);
+        var 예상_채팅_내용들 = 채팅_검색_결과들(
+                채팅_검색_결과(
+                        말랑채팅_ID,
+                        1L,
+                        "말랑",
+                        BACKEND,
+                        "안녕? - 좋아요",
+                        2,
+                        1,
+                        검색시_조회될_채팅_키워드()
+                ),
+                채팅_검색_결과(
+                        허브채팅_ID,
+                        2L,
+                        "허브",
+                        ANDROID,
+                        "안녕? - 좋아요",
+                        1,
+                        1,
+                        검색시_조회될_채팅_키워드())
+        );
+        검색_결과의_내용_검증(검색_결과, 예상_채팅_내용들);
     }
 }

--- a/src/test/java/chat/teco/tecochat/chat/fixture/ChatFixture.java
+++ b/src/test/java/chat/teco/tecochat/chat/fixture/ChatFixture.java
@@ -68,13 +68,13 @@ public class ChatFixture {
         return result;
     }
 
-    public static List<SearchChatResponse> 채팅_검색의_예상_결과들(
+    public static List<SearchChatResponse> 채팅_검색_결과들(
             SearchChatResponse... 채팅_검색의_예상_결과들
     ) {
         return List.of(채팅_검색의_예상_결과들);
     }
 
-    public static SearchChatResponse 채팅_검색의_예상_결과(
+    public static SearchChatResponse 채팅_검색_결과(
             Long 채팅_ID,
             Long 채팅한_크루_Id,
             String 채팅한_크루_이름,

--- a/src/test/java/chat/teco/tecochat/chat/query/dao/ChatQueryDaoTest.java
+++ b/src/test/java/chat/teco/tecochat/chat/query/dao/ChatQueryDaoTest.java
@@ -4,6 +4,9 @@ import static chat.teco.tecochat.chat.domain.chat.GptModel.GPT_3_5_TURBO;
 import static chat.teco.tecochat.member.domain.Course.ANDROID;
 import static chat.teco.tecochat.member.domain.Course.BACKEND;
 import static chat.teco.tecochat.member.domain.Course.FRONTEND;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.LocalTime.MIN;
+import static java.time.temporal.TemporalAdjusters.previousOrSame;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -14,22 +17,29 @@ import chat.teco.tecochat.chat.domain.chat.Question;
 import chat.teco.tecochat.chat.domain.chat.QuestionAndAnswer;
 import chat.teco.tecochat.chat.domain.chat.SettingMessage;
 import chat.teco.tecochat.chat.query.dao.ChatQueryDao.ChatSearchCond;
+import chat.teco.tecochat.chat.query.dao.ChatQueryDao.LikeCond;
 import chat.teco.tecochat.common.config.JpaConfig;
 import chat.teco.tecochat.common.config.QueryDslConfig;
+import chat.teco.tecochat.like.chatlike.domain.ChatLike;
+import chat.teco.tecochat.like.chatlike.domain.ChatLikeRepository;
 import chat.teco.tecochat.member.domain.Member;
 import chat.teco.tecochat.member.domain.MemberRepository;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
@@ -50,18 +60,28 @@ class ChatQueryDaoTest {
     @Autowired
     private ChatRepository chatRepository;
 
+    @Autowired
+    private ChatLikeRepository chatLikeRepository;
+
+    private Chat 채팅1;
+    private Chat 채팅2;
+    private Chat 채팅3;
+    private Chat 채팅4;
+    private Chat 채팅5;
+    private Chat 채팅6;
+
     @BeforeEach
     void setUp() {
-        saveMemberChat(memberRepository.save(new Member("프론트엔드허브", FRONTEND)));
-        saveMemberChat(memberRepository.save(new Member("프론트엔드말랑", FRONTEND)));
-        saveMemberChat(memberRepository.save(new Member("안드로이드허브", ANDROID)));
-        saveMemberChat(memberRepository.save(new Member("안드로이드말랑", ANDROID)));
-        saveMemberChat(memberRepository.save(new Member("백엔드허브", BACKEND)));
-        saveMemberChat(memberRepository.save(new Member("백엔드말랑", BACKEND)));
+        채팅1 = saveMemberChat(memberRepository.save(new Member("프론트엔드허브", FRONTEND)));
+        채팅2 = saveMemberChat(memberRepository.save(new Member("프론트엔드말랑", FRONTEND)));
+        채팅3 = saveMemberChat(memberRepository.save(new Member("안드로이드허브", ANDROID)));
+        채팅4 = saveMemberChat(memberRepository.save(new Member("안드로이드말랑", ANDROID)));
+        채팅5 = saveMemberChat(memberRepository.save(new Member("백엔드허브", BACKEND)));
+        채팅6 = saveMemberChat(memberRepository.save(new Member("백엔드말랑", BACKEND)));
         flushAndClear();
     }
 
-    private void saveMemberChat(Member member) {
+    private Chat saveMemberChat(Member member) {
         Chat chat = new Chat(GPT_3_5_TURBO,
                 SettingMessage.byCourse(member.course()),
                 member.name() + "의 Title",
@@ -73,14 +93,14 @@ class ChatQueryDaoTest {
                 7
         );
         chat.addQuestionAndAnswer(qna);
-        chatRepository.save(chat);
+        return chatRepository.save(chat);
     }
 
     @Test
     void 검색_조건이_설정되지_않으면_페이징하며_전체_조회() {
         // when
         Page<Chat> search = chatQueryDao.search(
-                new ChatSearchCond(null, null, null),
+                new ChatSearchCond(null, null, null, null),
                 PageRequest.of(0, 20));
 
         // then
@@ -95,7 +115,7 @@ class ChatQueryDaoTest {
     @Test
     void 이름으로_검색_가능() {
         // when
-        Page<Chat> search = chatQueryDao.search(new ChatSearchCond("말", null, null),
+        Page<Chat> search = chatQueryDao.search(new ChatSearchCond("말", null, null, null),
                 PageRequest.of(0, 20));
 
         // then
@@ -116,7 +136,7 @@ class ChatQueryDaoTest {
     @Test
     void 제목으로_검색_가능() {
         // when
-        Page<Chat> search = chatQueryDao.search(new ChatSearchCond(null, " 엔드허브의 tiTlE    ", null),
+        Page<Chat> search = chatQueryDao.search(new ChatSearchCond(null, " 엔드허브의 tiTlE    ", null, null),
                 PageRequest.of(0, 20));
 
         // then
@@ -135,7 +155,7 @@ class ChatQueryDaoTest {
     void 과정으로_검색_가능() {
         // when
         Page<Chat> search = chatQueryDao.search(
-                new ChatSearchCond(null, null, ANDROID),
+                new ChatSearchCond(null, null, ANDROID, null),
                 PageRequest.of(0, 20));
 
         // then
@@ -154,7 +174,7 @@ class ChatQueryDaoTest {
     void 이름_제목_과정으로_검색_가능() {
         // when
         Page<Chat> search = chatQueryDao.search(
-                new ChatSearchCond("말랑_좋아요", "허브_좋아요", BACKEND),
+                new ChatSearchCond("말랑_좋아요", "허브_좋아요", BACKEND, null),
                 PageRequest.of(0, 20));
 
         // then
@@ -165,5 +185,203 @@ class ChatQueryDaoTest {
     private void flushAndClear() {
         em.flush();
         em.clear();
+    }
+
+    @Nested
+    class 좋아요_순으로_정렬_시 {
+
+        // 진짜 혹시나 하루가 넘어가는 시점에 실행하면 터질수도?
+        private final LocalDateTime 오늘 = LocalDateTime.now().with(MIN);
+        private final LocalDateTime 어제 = LocalDateTime.now().minusDays(1).with(MIN);
+        private final LocalDateTime 이번주_시작 = LocalDateTime.now().with(previousOrSame(MONDAY)).with(MIN);
+        private final LocalDateTime 저번주 = LocalDateTime.now().minusWeeks(1).with(MIN);
+        private final LocalDateTime 이번달_시작 = LocalDateTime.now().withDayOfMonth(1).with(LocalTime.MIN);
+        private final LocalDateTime 저번달 = LocalDateTime.now().minusMonths(1).with(MIN);
+        private final LocalDateTime 올해_시작 = LocalDateTime.now().withDayOfYear(1).with(LocalTime.MIN);
+        private final LocalDateTime 작년 = LocalDateTime.now().minusYears(1).with(MIN);
+
+        @BeforeEach
+        void setUp() {
+            채팅1 = chatRepository.findById(채팅1.id()).get();
+            채팅2 = chatRepository.findById(채팅2.id()).get();
+            채팅3 = chatRepository.findById(채팅3.id()).get();
+            채팅4 = chatRepository.findById(채팅4.id()).get();
+            채팅5 = chatRepository.findById(채팅5.id()).get();
+            채팅6 = chatRepository.findById(채팅6.id()).get();
+        }
+
+        @Test
+        void 오늘_가장_좋아요를_많이_받은_게시물_순으로_조회한다() {
+            // given
+            좋아요(1L, 채팅4, 오늘);
+            좋아요(2L, 채팅4, 오늘);
+            좋아요(3L, 채팅4, 오늘);
+            좋아요(4L, 채팅2, 오늘);
+            좋아요(5L, 채팅2, 오늘);
+            좋아요(5L, 채팅3, 오늘);
+
+            // 아래 데이터는 어제 저장되었으므로 제외
+            좋아요(1L, 채팅1, 어제);
+            좋아요(2L, 채팅1, 이번달_시작);
+            좋아요(3L, 채팅1, 올해_시작);
+
+            // when
+            Page<Chat> search = chatQueryDao.search(
+                    new ChatSearchCond(null, null, null, LikeCond.TODAY),
+                    PageRequest.of(0, 20));
+
+            // then
+            List<Chat> expected = List.of(
+                    채팅4,
+                    채팅2,
+                    채팅3
+            );
+            assertThat(search.getContent())
+                    .usingRecursiveComparison()
+                    .ignoringExpectedNullFields()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 이번주에_가장_많은_좋아요를_많이_받은_게시물_순으로_조회한다() {
+            // given
+            좋아요(1L, 채팅3, 오늘);
+            좋아요(3L, 채팅3, 어제);
+            좋아요(2L, 채팅3, 이번주_시작);
+            좋아요(3L, 채팅6, 어제);
+            좋아요(1L, 채팅6, 이번주_시작);
+            좋아요(1L, 채팅5, 이번주_시작);
+
+            // 아래 데이터는 저번주에 저장되었으므로 제외
+            좋아요(1L, 채팅1, 저번주);
+            좋아요(2L, 채팅1, 저번주);
+            좋아요(3L, 채팅1, 올해_시작);
+
+            // when
+            Page<Chat> search = chatQueryDao.search(
+                    new ChatSearchCond(null, null, null, LikeCond.WEEK),
+                    PageRequest.of(0, 20));
+
+            // then
+            List<Chat> expected = List.of(
+                    채팅3,
+                    채팅6,
+                    채팅5
+            );
+            assertThat(search.getContent())
+                    .usingRecursiveComparison()
+                    .ignoringExpectedNullFields()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 이번달에_가장_많은_좋아요를_받은_게시물_순으로_조회한다() {
+            // given
+            좋아요(1L, 채팅3, 오늘);
+            좋아요(3L, 채팅3, 어제);
+            좋아요(2L, 채팅3, 이번달_시작);
+            좋아요(3L, 채팅6, 이번달_시작);
+            좋아요(1L, 채팅6, 이번달_시작);
+            좋아요(1L, 채팅5, 저번주);
+            좋아요(4L, 채팅2, 이번주_시작);
+
+            // 아래 데이터는 저번주에 저장되었으므로 제외
+            좋아요(1L, 채팅1, 저번달);
+            좋아요(2L, 채팅1, 저번달);
+            좋아요(3L, 채팅1, 올해_시작);
+
+            // when
+            Page<Chat> search = chatQueryDao.search(
+                    new ChatSearchCond(null, null, null, LikeCond.MONTH),
+                    PageRequest.of(0, 20));
+
+            // then
+            List<Chat> expected = List.of(
+                    채팅3,
+                    채팅6,
+                    채팅5,
+                    채팅2
+            );
+            assertThat(search.getContent())
+                    .usingRecursiveComparison()
+                    .ignoringExpectedNullFields()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 올해_가장_많은_좋아요를_받은_게시물_순으로_조회한다() {
+            // given
+            좋아요(1L, 채팅3, 오늘);
+            좋아요(3L, 채팅3, 어제);
+            좋아요(2L, 채팅3, 이번달_시작);
+            좋아요(3L, 채팅6, 올해_시작);
+            좋아요(1L, 채팅6, 올해_시작);
+            좋아요(1L, 채팅5, 저번달);
+            좋아요(4L, 채팅2, 이번주_시작);
+
+            // 아래 데이터는 저번주에 저장되었으므로 제외
+            좋아요(1L, 채팅1, 작년);
+            좋아요(2L, 채팅1, 작년);
+            좋아요(3L, 채팅1, 작년);
+
+            // when
+            Page<Chat> search = chatQueryDao.search(
+                    new ChatSearchCond(null, null, null, LikeCond.YEAR),
+                    PageRequest.of(0, 20));
+
+            // then
+            List<Chat> expected = List.of(
+                    채팅3,
+                    채팅6,
+                    채팅5,
+                    채팅2
+            );
+            assertThat(search.getContent())
+                    .usingRecursiveComparison()
+                    .ignoringExpectedNullFields()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void 전체_기간동안_가장_많은_좋아요를_받은_게시물을_조회한다() {
+            // given
+            좋아요(1L, 채팅3, 오늘);
+            좋아요(3L, 채팅3, 어제);
+            좋아요(2L, 채팅3, 이번달_시작);
+            좋아요(3L, 채팅6, 올해_시작);
+            좋아요(1L, 채팅6, 올해_시작);
+            좋아요(1L, 채팅5, 저번달);
+            좋아요(4L, 채팅2, 이번주_시작);
+            좋아요(1L, 채팅1, 작년);
+            좋아요(2L, 채팅1, 작년);
+            좋아요(3L, 채팅1, 작년);
+
+            // when
+            Page<Chat> search = chatQueryDao.search(
+                    new ChatSearchCond(null, null, null, LikeCond.ALL),
+                    PageRequest.of(0, 20));
+
+            // then
+            List<Chat> expected = List.of(
+                    채팅3,
+                    채팅1,
+                    채팅6,
+                    채팅5,
+                    채팅2,
+                    채팅4  // 전체 기간의 경우 좋아요가 없더라도 보여줌
+            );
+            assertThat(search.getContent())
+                    .usingRecursiveComparison()
+                    .ignoringExpectedNullFields()
+                    .isEqualTo(expected);
+        }
+
+        private void 좋아요(long 회원_ID, Chat 채팅, LocalDateTime 생성시간) {
+            채팅.increaseLike();
+            ChatLike chatLike = new ChatLike(회원_ID, 채팅.id());
+            ChatLike save = chatLikeRepository.save(chatLike);
+            ReflectionTestUtils.setField(save, "createdAt", 생성시간);
+            em.flush();
+        }
     }
 }

--- a/src/test/java/chat/teco/tecochat/chat/query/usecase/SearchChatUseCaseTest.java
+++ b/src/test/java/chat/teco/tecochat/chat/query/usecase/SearchChatUseCaseTest.java
@@ -42,7 +42,7 @@ class SearchChatUseCaseTest extends ChatQueryUseCaseTest {
 
         // when
         Page<SearchChatResponse> search = searchChatUseCase.search(
-                new ChatSearchCond(null, null, null),
+                new ChatSearchCond(null, null, null, null),
                 PageRequest.of(1, 1)
         );
 


### PR DESCRIPTION
- 전체 기간이 아닌, 오늘, 이번주, 이번달에 대해서 검색하는 경우, 해당 기간에 새로 달린 좋아요가 없다면 조회되지 않는다.
- 뭔가 chatGpt 모킹 과정에서 잘못되었는지 detached entity passed to persist QuestionAnsAnswer 가 발생, 일단 임시방편으로 해결함